### PR TITLE
fixed emeter voltage, current and total variables

### DIFF
--- a/kasa/emeter.go
+++ b/kasa/emeter.go
@@ -8,10 +8,10 @@ type GetRealtimeRequest struct {
 }
 
 type GetRealtimeResponse struct {
-	Current float64 `mapstructure:"current"`
-	Voltage float64 `mapstructure:"voltage"`
-	Power   float64 `mapstructure:"power"`
-	Total   float64 `mapstructure:"total"`
+	Current float64 `mapstructure:"current_ma"`
+	Voltage float64 `mapstructure:"voltage_mv"`
+	Power   float64 `mapstructure:"power_mw"`
+	Total   float64 `mapstructure:"total_wh"`
 }
 
 func (s *KasaClientEmeterService) GetRealtime() (*GetRealtimeResponse, error) {


### PR DESCRIPTION
Fixes Issue: https://github.com/fffonion/tplink-plug-exporter/issues/1

Variables were renamed, so that the output of the energy values is correct again.