### PR TITLE
Enable Dockerfile to produce arm64 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM golang:1.12-alpine AS builder
-ADD . /src
-RUN apk add --no-cache git
-WORKDIR /src
-RUN go build main.go
+FROM golang:1.12 as builder
 
-FROM alpine:latest
+ARG GOARCH=amd64
+ARG GOOS=linux
+
+COPY . /src
+WORKDIR /src
+RUN GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build main.go
+
+FROM alpine:3.12.1
 COPY --from=builder /src/main /tplink-plug-exporter
 EXPOSE 9233
 ENTRYPOINT ["/tplink-plug-exporter"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ scrape_configs:
         - localhost:9233
 ```
 
+## Docker Build Instructions
+
+Build for both `arm64` and `amd64`:
+```
+docker build -t <image-name>:latest-arm64 --platform linux/arm64 --build-arg GOARCH=arm64 .
+docker build -t <image-name>:latest-amd64 --platform linux/amd64 --build-arg GOARCH=amd64 .
+```
+
+Merge them in one manifest:
+```
+docker manifest create <image-name>:latest --amend <image-name>:latest-arm64 --amend <image-name>:latest-amd64
+docker manifest push <image-name>:latest
+```
+
 ## See also
 
 - Original reverse engineering work: https://github.com/softScheck/tplink-smartplug


### PR DESCRIPTION
Adds necessary bits to enable `Dockerfile` to be able to produce `arm64` images. Tested with RaspberryPi and it works as expected.

Thank you for the project!