### PR TITLE
Update Dockerfile to go version 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.18 as builder
 
 ARG GOARCH=amd64
 ARG GOOS=linux


### PR DESCRIPTION
The current build will not succeed, as the go.mod has been updated to 1.18.